### PR TITLE
fix: stringify for normalization json-pointer for JSON string data

### DIFF
--- a/src/merkle/normalization/json-pointer.ts
+++ b/src/merkle/normalization/json-pointer.ts
@@ -3,7 +3,9 @@ import pointer from 'json-pointer';
 const objectToMessages = (obj: any) => {
   const dict = pointer.dict(obj);
   const messages = Object.keys(dict).map(key => {
-    return `{"${key}": "${dict[key]}"}`;
+    const messageObj: { [k: string]: any } = {};
+    messageObj[key] = dict[key];
+    return JSON.stringify(messageObj);
   });
   return messages;
 };


### PR DESCRIPTION
When createProof using the normalization `json-pointer` with the document content the value is JSON string, that will raise an error.
Example document:
```
{
  "@context": [
    "https://www.w3.org/2018/credentials/v1",
    "https://www.w3.org/2018/credentials/examples/v1"
  ],
  "type": [
    "VerifiableCredential",
    "UniversityDegreeCredential"
  ],
  "credentialSubject": {
    "name": "Jane Smith",
    "degree": {
      "type": "BachelorDegree",
      "name": "Bachelor of Science and Arts",
      "degreeSchool": "{\"name\": \"Example University\"}"
    }
  },
  "issuer": {
    "id": "did:web:example.com"
  }
}
```
